### PR TITLE
Copyrighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ services:
 
 ```bash
 # Deploy to default namespace
-kubectl apply -f https://raw.githubusercontent.com/pocketminers/nfs-server/main/examples/deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/boyroywax/nfs-server/main/examples/deployment.yaml
 
 # Deploy to specific namespace
-kubectl apply -f https://raw.githubusercontent.com/pocketminers/nfs-server/main/examples/deployment.yaml -n your-namespace
+kubectl apply -f https://raw.githubusercontent.com/boyroywax/nfs-server/main/examples/deployment.yaml -n your-namespace
 ```
 
 ### Custom Deployment

--- a/README.md
+++ b/README.md
@@ -353,4 +353,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 Built with ❤️ for the cloud-native community.
 
-For questions, issues, or contributions, please visit our [GitHub repository](https://github.com/pocketminers/nfs-server).
+For questions, issues, or contributions, please visit our [GitHub repository](https://github.com/boyroywax/nfs-server).


### PR DESCRIPTION
This pull request updates project references in the `README.md` file to point to the new GitHub repository location. The changes ensure that deployment instructions and contribution links direct users to the correct repository.

Repository reference updates:

* Updated deployment instructions in `README.md` to use the new repository URL (`boyroywax/nfs-server`) instead of the old one (`pocketminers/nfs-server`).
* Changed the contribution and issues link at the end of `README.md` to reference the new repository.